### PR TITLE
Add saved custom lists (localStorage) and propose theme via GitHub Issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,13 +16,24 @@
             <p class="instruction">Choisis un thème :</p>
             <div id="theme-grid"></div>
 
+            <!-- Section listes sauvegardées (cachée si vide) -->
+            <div id="saved-lists-section" style="display: none;">
+                <div class="separator">Mes listes</div>
+                <div id="saved-lists-grid"></div>
+            </div>
+
             <div class="separator">ou crée ta propre liste</div>
 
+            <input type="text" id="custom-list-name" placeholder="Nom de ta liste (ex : Les fruits)">
             <p class="hint">Format : anglais = français</p>
             <textarea id="word-list-input" rows="6" placeholder="Apple = Pomme
 House = Maison
 Dog = Chien"></textarea>
             <button id="start-custom-btn">Jouer avec ma liste</button>
+            <div id="custom-actions" style="display: none;">
+                <button id="save-list-btn" class="btn-secondary btn-small">Sauvegarder ma liste</button>
+                <button id="propose-theme-btn" class="btn-secondary btn-small">Proposer ce thème</button>
+            </div>
         </div>
 
         <!-- Écran de choix du mode de jeu -->

--- a/style.css
+++ b/style.css
@@ -438,3 +438,84 @@ textarea:focus {
     gap: 10px;
     margin-top: 15px;
 }
+
+/* Saved lists grid */
+#saved-lists-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px;
+    margin: 15px 0;
+    max-height: 260px;
+    overflow-y: auto;
+    padding-right: 5px;
+}
+
+#saved-lists-grid::-webkit-scrollbar {
+    width: 6px;
+}
+
+#saved-lists-grid::-webkit-scrollbar-track {
+    background: #f1f3f0;
+    border-radius: 3px;
+}
+
+#saved-lists-grid::-webkit-scrollbar-thumb {
+    background: #a3b18a;
+    border-radius: 3px;
+}
+
+.saved-list-btn {
+    padding: 12px 10px;
+    font-size: 0.85rem;
+    border-radius: 15px;
+    background: #f1f3f0;
+    color: #344e41;
+    border: 1px solid #dad7cd;
+    font-weight: 600;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 6px;
+}
+
+.saved-list-btn:hover {
+    background: #588157;
+    color: white;
+    border-color: #588157;
+    transform: translateY(-2px);
+}
+
+.saved-list-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.saved-list-delete {
+    font-size: 1.1rem;
+    line-height: 1;
+    opacity: 0.6;
+    flex-shrink: 0;
+}
+
+.saved-list-delete:hover {
+    opacity: 1;
+}
+
+/* Custom action buttons */
+#custom-actions {
+    display: flex;
+    gap: 10px;
+    margin-top: 10px;
+}
+
+.btn-small {
+    padding: 10px 12px;
+    font-size: 0.8rem;
+}
+
+#custom-list-name {
+    margin: 10px 0 5px;
+    padding: 12px 15px;
+    font-size: 0.9rem;
+}


### PR DESCRIPTION
- Persist custom word lists in localStorage with save/delete
- Display saved lists in a "Mes listes" grid on the setup screen
- Add "Proposer ce thème" button to open a pre-filled GitHub Issue
- Require a list name before enabling save/propose actions